### PR TITLE
chore: upgrade podium element

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,34 +36,39 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@podium/element": "1.0.8",
+    "@podium/element": "1.1.0",
     "construct-style-sheets-polyfill": "3.1.0",
     "lit": "3.0.0"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "7.23.3",
     "@eik/cli": "^2.0.22",
     "@eik/esbuild-plugin": "^1.1.36",
-    "@types/node": "^20.4.7",
-    "esbuild": "^0.19.3",
-    "typescript": "^5.1.6",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/commit-analyzer": "11.1.0",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "9.2.4",
     "@semantic-release/npm": "11.0.1",
     "@semantic-release/release-notes-generator": "12.1.0",
-    "semantic-release": "22.0.8",
-    "@babel/eslint-parser": "7.23.3",
+    "@types/node": "^20.4.7",
+    "esbuild": "^0.19.3",
     "eslint": "8.54.0",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-config-prettier": "9.0.0",
     "eslint-plugin-import": "2.29.0",
     "eslint-plugin-prettier": "5.0.1",
-    "prettier": "3.1.0"
+    "prettier": "3.1.0",
+    "semantic-release": "22.0.8",
+    "typescript": "^5.1.6"
   },
   "eik": {
     "server": "https://assets.finn.no",
     "files": "./dist",
     "import-map": "https://assets.finn.no/map/custom-elements/v2"
+  },
+  "pnpm": {
+    "ignoredBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
pnpm re-ordered some deps in the list, and the new pnpm 10 added the ignoredBuiltDependencies to ensure esbuild is allowed to be built.