### PR TITLE
fix: update eik import map

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
   "eik": {
     "server": "https://assets.finn.no",
     "files": "./dist",
-    "import-map": "https://assets.finn.no/map/custom-elements/v2"
+    "import-map": "https://assets.finn.no/map/lit/v3"
   }
 }


### PR DESCRIPTION
Use Lit import map instead of deprecated custom-elements import map